### PR TITLE
Fix duplicate Entity identifiers

### DIFF
--- a/app/service_objects/entity_merger.rb
+++ b/app/service_objects/entity_merger.rb
@@ -54,7 +54,9 @@ class EntityMerger
   end
 
   def merge_identifiers
-    @to_keep.identifiers.concat @to_remove.identifiers
+    @to_remove.identifiers.each do |identifier|
+      @to_keep.identifiers << identifier unless @to_keep.identifiers.include? identifier
+    end
   end
 
   def update_references!

--- a/app/views/pages/data_changelog.html.haml
+++ b/app/views/pages/data_changelog.html.haml
@@ -21,6 +21,43 @@
             as a user of our data. Where possible, we'll identify directly
             which releases of bulk data you'll see these changes in.
 
+          %h2 08 Juyl 2020
+          %p
+            <strong>First affected bulk download:</strong> August 2020
+
+          %ul
+            %li
+              %p
+                After a report of duplicate identifiers for UK companies in our
+                output we investigated and realised that we were assigning some
+                company numbers under the wrong identifier scheme. We were also
+                missing an opportunity to output the internal "self link"
+                identifier that Companies House give to Relevant Legal Entities
+                (i.e. intermediate or ultimate corporate owners).
+              %p
+                This affects approximately 28,000 companies from the UK PSC data
+                that were reported as owners of another company and where the
+                disclosure included a 'registration number'. Before, we would
+                output that registration number as a company number under the
+                'GB-COH' scheme (when the company was declared as being in the
+                UK jurisdiction). Now, we output it under a new named scheme
+                "GB Persons Of Significant Control Register - Registration
+                numbers" - to make it clear that the data is not verified and
+                therefore not directly comparable to the identifiers we output
+                from companies' own direct disclosures.
+              %p
+                In most cases, this will simply mean that we output an
+                additional identifier, because we will also give one under the
+                GB-COH scheme. For total accuracy, you should compare entities
+                via the OpenOwnership register identifiers and remove GB-COH
+                identifiers where they no longer appear in our data.
+              %p
+                In addition, we now output Companies House's internal
+                'self link' identifiers for all owners, whether legal entity or
+                natural person. We previously did this for all people, and legal
+                entities that had no registration number or where not UK
+                companies, so you should simply see more identifiers for some UK
+                companies.
           %h2 09 December 2019
           %p
             <strong>First affected bulk download:</strong> 10th December 2019
@@ -74,6 +111,3 @@
               %ul
               - @exports.each do |export|
                 %li= link_to export.created_at.to_date, "https://oo-register-production.s3-eu-west-1.amazonaws.com/public/exports/statements.#{export.created_at.iso8601}.jsonl.gz", rel: 'nofollow'
-
-
-

--- a/app/views/pages/download.html.haml
+++ b/app/views/pages/download.html.haml
@@ -302,6 +302,7 @@
             %li <i>DK Centrale Virksomhedsregister</i>: <code>enhedsNummer</code>
             %li <i>SK Register Partnerov Verejného Sektora</i>: <code>KonecniUzivateliaVyhod.Id</code>
             %li <i>GB Persons Of Significant Control Register</i>: beneficial owner "self links"
+            %li <i>GB Persons Of Significant Control Register - Registration numbers</i>: beneficial owner "registration numbers". i.e. unverified company registration numbers.
             %li <i>UA Edinyy Derzhavnyj Reestr</i>: company number and beneficial owner name
             %li <i>EITI 2013-2015 beneficial ownership pilots</i>: beneficial owner name
           %p

--- a/lib/tasks/migrations/202007031623_dedupe_identifiers.rake
+++ b/lib/tasks/migrations/202007031623_dedupe_identifiers.rake
@@ -1,0 +1,13 @@
+namespace :migrations do
+  desc "Removes duplicates from all entity identifiers"
+  task :dedupe_identifiers => :environment do
+    Entity.each do |entity|
+      identifiers_before = entity.identifiers
+      unique_identifiers = identifiers_before.uniq
+      if unique_identifiers.count < identifiers_before.count
+        entity.update_attribute('identifiers', unique_identifiers)
+        Rails.logger.info "Removed #{identifiers_before.count - unique_identifiers.count} duplicate identifiers from entity: #{entity.id}"
+      end
+    end
+  end
+end

--- a/spec/shared_contexts/bods.rb
+++ b/spec/shared_contexts/bods.rb
@@ -205,6 +205,10 @@ RSpec.shared_context 'BODS: company that is part of a chain of relationships' do
             'id' => 'fooo',
           },
           {
+            'schemeName' => 'GB Persons Of Significant Control Register - Registration numbers',
+            'id' => '67890',
+          },
+          {
             'schemeName' => 'OpenOwnership Register',
             'id' => Rails.application.routes.url_helpers.entity_url(legal_entity_2),
             'uri' => Rails.application.routes.url_helpers.entity_url(legal_entity_2),


### PR DESCRIPTION
This changes the entity merge process (called during imports whenever we find companies that match existing companies in the DB) so that it doesn't just append identifiers to a list, but de-dupes that list (i.e. only appends new ones).

In addition, there's a data migration to clean up the existing dupes.

However, this wasn't the only cause of dupes in the BODS output (where this was first spotted), because we were also transforming some identifiers from UK PSC data, resulting in dupes appearing even when identifiers differed. This was fixed in the BODS output mapper as a quick fix, though the long term solution would be to do #15 and make additional identifiers at import time.