### PR TITLE
Anonymize IPs sent to GA and turn off cookies

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -24,7 +24,7 @@ module ApplicationHelper
           function gtag(){dataLayer.push(arguments);}
           gtag('js', new Date());
 
-          gtag('config', '#{Rails.application.config.ga_tracking_id}');
+          gtag('config', '#{Rails.application.config.ga_tracking_id}', { anonymize_ip: true, client_storage: 'none' });
         </script>
         GA
       ),


### PR DESCRIPTION
We can still get considerable value from Google Analytics without
IP addresses that identify people, or cookies that track them across
page views etc. On balance (vs annoying cookie popups) this seems a
better user experience all round.