### PR TITLE
Don't collect any personal data with Rollbar

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,7 +226,7 @@ GEM
       mongoid-compatibility
       stringex (~> 2.0)
     msgpack (1.2.6)
-    multi_json (1.13.1)
+    multi_json (1.15.0)
     multipart-post (2.1.1)
     net-http-persistent (2.9.4)
     nio4r (2.5.2)
@@ -303,8 +303,7 @@ GEM
     roadie-rails (1.3.0)
       railties (>= 3.0, < 5.3)
       roadie (~> 3.1)
-    rollbar (2.18.2)
-      multi_json
+    rollbar (2.27.0)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)

--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -1,5 +1,11 @@
 Rollbar.configure do |config|
   config.access_token = ENV['ROLLBAR_ACCESS_TOKEN']
+  config.anonymize_user_ip = true
+  config.scrub_fields << [:user_email]
+  # Only collect ids, no personal data
+  config.person_username_method = ''
+  config.person_email_method = ''
+
   config.enabled = false if Rails.env.test? || Rails.env.development?
   if config.enabled
     config.environment = (PullRequestNumber.call || ENV.fetch('ROLLBAR_ENV'))


### PR DESCRIPTION
To save us having to explain and get consent for it, we can just tell
Rollbar to anonymise IP addresses, skip emails and only collect our
internal user ids so that they don't have any personal data.

Note that I also upgraded Rollbar to the latest, to make sure we could use all the GDPR-related features