### PR TITLE
Add Open Ownership to the Register DB

### DIFF
--- a/app/models/unknown_persons_entity.rb
+++ b/app/models/unknown_persons_entity.rb
@@ -28,7 +28,7 @@ class UnknownPersonsEntity < Entity
   def name
     return self[:name] if self[:name].present?
 
-    if unknown_reason_code == 'no-individual-or-entity-with-signficant-control'
+    if %w[no-individual-or-entity-with-signficant-control open-ownership].include?(unknown_reason_code)
       I18n.t("unknown_persons_entity.names.no_person")
     else
       I18n.t("unknown_persons_entity.names.unknown")

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -288,7 +288,7 @@ en:
     disclosure-transparency-rules-chapter-five-applies: "The company has been or is exempt from keeping a PSC register, because it is a DTR issuer and the shares are admitted to trading on a regulated market."
     psc-exempt-as-trading-on-regulated-market: "The company has been or is exempt from keeping a PSC register, as it has voting shares admitted to trading on a regulated market other than the UK."
     psc-exempt-as-shares-admitted-on-market: "The company has been or is exempt from keeping a PSC register, as it has voting shares admitted to trading on a market listed in the Register of People with Significant Control Regulations 2016."
-
+    open-ownership: "Open Ownership is a non-profit run by a small, expert team well positioned to support countries implementing beneficial ownership transparency (BOT). Our day-to-day management relies on an executive team who are overseen by a Steering Group made up of leading transparency and accountability organisations. In order to focus on our mission, Open Ownership is fiscally sponsored by Global Impact. Fiscal sponsorship is a common mechanism in the non-profit sector that enables organisations to launch new programmes without needing to complete the full process of establishing a new legal entity. The Steering Group and our partners help ensure that our organisation is strategic and focused on our mission. The Steering Group also contributes to fundraising and publicly champions BOT."
   relationship_interests:
     shareholding: "Ownership of shares"
     shareholding-exact: "Ownership of shares - %{share}%"

--- a/lib/tasks/migrations/202008201620_add_oo_entity.rake
+++ b/lib/tasks/migrations/202008201620_add_oo_entity.rake
@@ -1,0 +1,23 @@
+namespace :migrations do
+  desc "Adds an entity record for OO"
+  task :add_oo_entity => :environment do
+    oo = Entity.create!(
+      name: "Open Ownership",
+      type: Entity::Types::LEGAL_ENTITY,
+      address: "1199 N. Fairfax St., Suite 300, Alexandria, VA 22314",
+      identifiers: [
+        {
+          document_id: 'manual',
+          name: 'Open Ownership',
+          sponsor: 'Global Impact',
+        },
+      ],
+    )
+    Statement.create!(
+      id: { document_id: 'manual', sponsor: 'Global Impact' },
+      type: 'open-ownership',
+      entity: oo,
+    )
+    IndexEntityService.new(oo).index
+  end
+end


### PR DESCRIPTION
I'm using a custom statement type as a way to record the somewhat unique
nature of this setup, so that we don't have any more special cases than
are absolutely necessary in the code.

This is what it looks like:

![image](https://user-images.githubusercontent.com/663700/90792229-21849c00-e302-11ea-9fdc-eb0416e1cc7f.png)

## Deployment
- [ ] Run `rake migrations:add_oo_entity` to load the data into the DB
