### PR TITLE
Document pausing of Ukraine EDR data imports

### DIFF
--- a/app/views/pages/data_changelog.html.haml
+++ b/app/views/pages/data_changelog.html.haml
@@ -21,9 +21,29 @@
             as a user of our data. Where possible, we'll identify directly
             which releases of bulk data you'll see these changes in.
 
+          %h2 06 October 2020
+          %p
+            <strong>First affected bulk download:</strong> September 2020
+
+          %ul
+            %li
+              %p
+                The Ukrainian Consolidated State Register has recently launched
+                new register software which aims to capture better structured
+                data about beneficial owners of companies. Unfortunately, this
+                comes with a change to the format of their open data which means
+                we cannot currently process it.
+              %p
+                From this update onwards, the Ukrainian data in our register is
+                likely to fall out of date as we do not currently have the
+                resources to investigate the new data, ensure continuity or
+                update our import processes to adapt to the new format. We will
+                keep the existing data in place indefinitely whilst we explore
+                our options.
+
           %h2 08 July 2020
           %p
-            <strong>First affected bulk download:</strong> Unreleased (July 2020)
+            <strong>First affected bulk download:</strong> August 2020
 
           %ul
             %li

--- a/app/views/pages/download.html.haml
+++ b/app/views/pages/download.html.haml
@@ -40,7 +40,7 @@
             %li <a href="/data_sources/uk-psc-register">UK PSC Register</a> (regularly updated)
             %li <a href="/data_sources/dk-cvr-register">Denmark Central Business Register (CVR)</a> (regularly updated)
             %li <a href="/data_sources/sk-rpvs-register">Slovakia Public Sector Partners Register</a> (regularly updated)
-            %li <a href="/data_sources/ua-edr-register">Ukraine Unified States Register (EDR)</a> (regularly updated)
+            %li <a href="/data_sources/ua-edr-register">Ukraine Unified States Register (EDR)</a> (regularly updated until September 2020, now paused)
             %li <a href="https://eiti.org/">EITI</a> pilot data (data collected 2013-15)
             %li User submitted data
           %p

--- a/content/data_sources/ua-edr-register/overview.en.md
+++ b/content/data_sources/ua-edr-register/overview.en.md
@@ -1,6 +1,7 @@
 Beneficial ownership data in Ukraine has been publicly available as open data in
 the Unified State Register of Legal Entities and Individual Entrepreneurs (USR)
-since 2017.
+since 2017. We regularly imported this data until September 2020, when a data
+format change caused us to pause imports indefinitely.
 
 Ukrainian law refers to ‘controllers’ (контролери) as opposed to ‘founders’
 (засновниками) to differentiate beneficial ownership from legal


### PR DESCRIPTION
The data now contains a `<beneficiaries>` element where BO data should lie.
It's still not published as structured data, so we would need to adapt
our NLP-based ua-edr-extractor library to look in this field instead.
This will involve potentially significant development and particularly
testing which we're not well-placed to perform. This is before we get to
the issue of continuity between the data we already have (extracted from
a different data field) and whatever is in the new field.

For now, the best we can do is honestly document the situation for any
data users.