### PR TITLE
Make incremental BODS exports the non-default option

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -383,6 +383,7 @@ The setup process for this looks like:
   services.
   - `cd register`
   - `bin/setup-bods-export`
+  - Activate rbenv: `source ~/.bash_profile`
   - Edit `config/mongoid.yml` and change the development database to a `uri`
     setting like production, copying in the production connection string from
     Heroku
@@ -426,16 +427,7 @@ statement ids from S3.
 
 - Download the file from S3
 - Read each line into an array
-- Initialise the exporter with `existing_ids: your_array`
-
-#### To perform a wholly new export
-
-This is a temporary workaround to our data not containing change markers in
-the form of `replacesStatements` values.
-
-- Comment out the lines in `BodsExporter.entity_ids_to_export` that deal with
-  limiting the export to entities updated since the last export (everything
-  except the first and last line).
+- Initialise the exporter with `existing_ids: your_array` and `incremental: true`
 
 ### Monitoring exports
 
@@ -454,7 +446,6 @@ the form of `replacesStatements` values.
   (we only use the list for ordering) and takes up precious memory in Redis.
 - Find the export id from the export you just finished (it should be the same as
   the latest/only folder name in RAILS_ROOT/tmp/exports).
-- Decide whether you're creating a wholly new file, or an incremental update:
 
 **Note**: If you're starting a new rails shell to run this command, remember
 a) to do it in a Screen session (it takes hours so you'll want to disconnect)
@@ -470,19 +461,10 @@ volume's boost credits. If you forget, you have to kill the spring process
 before anything can start, because it keeps running in the background (hint: it
 doesn't appear in ps for your user either).
 
-#### Wholly new update (replacing existing ones)
-
-- This is a temporary workaround to our data not containing change markers in
-  the form of `replacesStatements` values.
-- Comment out the `download_from_s3` lines in `BodsExportUploader.call` (the
-  first two lines)
-- Run `BodsExportUploader.new(export_id).call`
-
 #### Incremental update
 
 - Assuming you ran the export with a primed list of existing statement ids!
-- Run `BodsExportUploader.new(export_id).call` (nothing out of the ordinary
-  needed, this should be the default)
+- Run `BodsExportUploader.new(export_id, incremental: true).call`
 
 ### Monitoring data combining/uploading
 

--- a/app/service_objects/bods_export_uploader.rb
+++ b/app/service_objects/bods_export_uploader.rb
@@ -2,8 +2,9 @@ class BodsExportUploader
   include SystemCallHelper
   attr_accessor :export_id
 
-  def initialize(export_id)
+  def initialize(export_id, incremental: false)
     @export = BodsExport.find(export_id)
+    @incremental = incremental
 
     @redis = Redis.new
 
@@ -27,8 +28,10 @@ class BodsExportUploader
   end
 
   def call
-    download_from_s3(@all_statements)
-    download_from_s3(@all_statement_ids)
+    if @incremental
+      download_from_s3(@all_statements)
+      download_from_s3(@all_statement_ids)
+    end
     append_new_statements
     upload_to_s3(@all_statements)
     upload_to_s3(@all_statement_ids)

--- a/spec/service_objects/bods_export_uploader_spec.rb
+++ b/spec/service_objects/bods_export_uploader_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe BodsExportUploader do
         to: "public/exports/statement-ids.#{export.created_at.iso8601}.txt.gz",
       )
 
-      BodsExportUploader.new(export.id).call
+      BodsExportUploader.new(export.id, incremental: true).call
 
       statements_json = Zlib::GzipReader.open(
         File.join(dir, 'statements.latest.jsonl.gz'),
@@ -171,7 +171,7 @@ RSpec.describe BodsExportUploader do
           to: "public/exports/statement-ids.#{export.created_at.iso8601}.txt.gz",
         )
 
-        BodsExportUploader.new(export.id).call
+        BodsExportUploader.new(export.id, incremental: true).call
 
         statements_json = Zlib::GzipReader.open(
           File.join(dir, 'statements.latest.jsonl.gz'),
@@ -206,7 +206,7 @@ RSpec.describe BodsExportUploader do
         contents: existing_statement_ids.join("\n") + "\n",
       )
       expect do
-        BodsExportUploader.new(export.id).call
+        BodsExportUploader.new(export.id, incremental: true).call
       end.to raise_error(RuntimeError)
     end
   end
@@ -246,7 +246,7 @@ RSpec.describe BodsExportUploader do
         to: "public/exports/statement-ids.#{export.created_at.iso8601}.txt.gz",
       )
 
-      BodsExportUploader.new(export.id).call
+      BodsExportUploader.new(export.id, incremental: true).call
 
       expect(export.reload.completed_at).to be_within(1.second).of(Time.zone.now)
     end

--- a/spec/service_objects/bods_exporter_spec.rb
+++ b/spec/service_objects/bods_exporter_spec.rb
@@ -46,6 +46,8 @@ RSpec.describe BodsExporter do
     end
 
     context "when there have been other completed exports" do
+      subject { BodsExporter.new(chunk_size: 1, incremental: true) }
+
       before do
         legal_entity_1.set(updated_at: '2019-01-01 00:00:00')
         legal_entity_2.set(updated_at: '2019-01-02 00:00:00')

--- a/spec/system/bods_export_spec.rb
+++ b/spec/system/bods_export_spec.rb
@@ -3,9 +3,9 @@ require 'rails_helper'
 RSpec.describe 'BODS Export' do
   include BodsExportHelpers
 
-  let(:exporter) { BodsExporter.new }
+  let(:exporter) { BodsExporter.new(incremental: true) }
   let(:export) { exporter.export }
-  let(:uploader) { BodsExportUploader.new(export.id) }
+  let(:uploader) { BodsExportUploader.new(export.id, incremental: true) }
   let(:latest_statements_url) { "https://#{ENV['BODS_EXPORT_S3_BUCKET_NAME']}.s3.eu-west-1.amazonaws.com/public/exports/statements.latest.jsonl.gz" }
   let(:latest_ids_url) { "https://#{ENV['BODS_EXPORT_S3_BUCKET_NAME']}.s3.eu-west-1.amazonaws.com/public/exports/statement-ids.latest.txt.gz" }
   let(:redis) { Redis.new }
@@ -253,7 +253,7 @@ RSpec.describe 'BODS Export' do
 
     let!(:existing_statement_ids) { existing_statements.map { |s| s["statementID"] } }
 
-    let(:exporter) { BodsExporter.new(existing_ids: existing_statement_ids) }
+    let(:exporter) { BodsExporter.new(existing_ids: existing_statement_ids, incremental: true) }
 
     before do
       sio = StringIO.new


### PR DESCRIPTION
We've had this functionality for ages but have to work around it on
every export by manually commenting out code. It's not likely that we'll
tackle all the issues stopping us from using it any time soon, so I've
made it sit behind a toggle parameter to the classes involved. Now we
don't have to edit code every time we do our 'normal' update.