### PR TITLE
Upgraded docker and Circle CI Elasticsearch to 8.3.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,12 +17,13 @@ jobs:
 
       - image: mongo:4.4.1
 
-      - image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5
+      - image: docker.elastic.co/elasticsearch/elasticsearch:8.3.2
         environment:
           - 'discovery.type=single-node'
           - 'cluster.name=register-elasticsearch'
           - 'bootstrap.memory_lock=true'
           - 'ES_JAVA_OPTS=-Xms512m -Xmx512m'
+          - 'xpack.security.enabled=false'
 
       - image: circleci/redis:4.0.9-alpine
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     restart: always
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.5
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.3.2
     volumes:
       - 'es_data:/usr/share/elasticsearch/data'
     environment:


### PR DESCRIPTION
- Searchly doesn't support Elasticsearch 8, so can't upgrade the
  gems past 7.10 yet.