### PR TITLE
Updated PSC Importer to ignore newly introduced record kinds

### DIFF
--- a/app/importers/psc_importer.rb
+++ b/app/importers/psc_importer.rb
@@ -41,6 +41,10 @@ class PscImporter
               "record: #{raw_record.id}"
         Rails.logger.warn msg
       end
+    when /(individual|corporate-entity|legal-person|super-secure)-beneficial-owner/
+      msg = "Skipping PSC record kind: #{record['data']['kind']} for #{raw_record.id}"
+      Rails.logger.warn msg
+      :ignore
     else
       raise "unexpected kind: #{record['data']['kind']}"
     end

--- a/spec/fixtures/files/psc_corporate-entity-beneficial-owner.json
+++ b/spec/fixtures/files/psc_corporate-entity-beneficial-owner.json
@@ -1,0 +1,1 @@
+{"company_number":"01234567","data":{"kind":"corporate-entity-beneficial-owner"}}

--- a/spec/fixtures/files/psc_individual-beneficial-owner.json
+++ b/spec/fixtures/files/psc_individual-beneficial-owner.json
@@ -1,0 +1,1 @@
+{"company_number":"01234567","data":{"kind":"individual-beneficial-owner"}}

--- a/spec/fixtures/files/psc_legal-person-beneficial-owner.json
+++ b/spec/fixtures/files/psc_legal-person-beneficial-owner.json
@@ -1,0 +1,1 @@
+{"company_number":"01234567","data":{"kind":"legal-person-beneficial-owner"}}

--- a/spec/fixtures/files/psc_super-secure-beneficial-owner.json
+++ b/spec/fixtures/files/psc_super-secure-beneficial-owner.json
@@ -1,0 +1,1 @@
+{"company_number":"01234567","data":{"kind":"super-secure-beneficial-owner"}}

--- a/spec/importers/psc_importer_spec.rb
+++ b/spec/importers/psc_importer_spec.rb
@@ -250,7 +250,7 @@ RSpec.describe PscImporter do
       expect(Relationship.count).to eq(0)
     end
 
-    ['individual', 'corporate-entity', 'legal-person', 'super-secure'].each do |bo_kind|
+    %w[individual corporate-entity legal-person super-secure].each do |bo_kind|
       it "ignores #{bo_kind}-beneficial-owner entries" do
         subject.process_records(psc_json_fixture("psc_#{bo_kind}-beneficial-owner.json"))
 

--- a/spec/importers/psc_importer_spec.rb
+++ b/spec/importers/psc_importer_spec.rb
@@ -250,6 +250,15 @@ RSpec.describe PscImporter do
       expect(Relationship.count).to eq(0)
     end
 
+    ['individual', 'corporate-entity', 'legal-person', 'super-secure'].each do |bo_kind|
+      it "ignores #{bo_kind}-beneficial-owner entries" do
+        subject.process_records(psc_json_fixture("psc_#{bo_kind}-beneficial-owner.json"))
+
+        expect(Entity.count).to eq(0)
+        expect(Relationship.count).to eq(0)
+      end
+    end
+
     context 'when there is a person with significant control statement' do
       it 'creates a statement linked to the entity' do
         allow(entity_resolver).to receive(:resolve!).with(


### PR DESCRIPTION
- Since Companies House have started to include registered overseas entities in their snapshots, they have introduced some new kinds of records. The previous code would error for a batch of records if any of the records contained an unknown type. This was causing entire batches of records to fail even if only one record was of unknown type.
- To fix the existing imports, the code has been updated to also ignore the newly introduced types, but to still error if there are new records introduced. These record kinds are:
    * 'individual-beneficial-owner'
    * 'corporate-entity-beneficial-owner'
    * 'legal-person-beneficial-owner'
    * 'super-secure-beneficial-owner'