### PR TITLE
Updated package.json to specify v16 for node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,4 +1,7 @@
 {
+  "engines": {
+    "node": "16.x"
+  },
   "dependencies": {
     "@rails/webpacker": "^5.4.3",
     "acorn": "^8.5.0",


### PR DESCRIPTION
- The default v18 was breaking on Heroku due to the legacy crypto options when installing packages