### PR TITLE
Release 2 merge prep

### DIFF
--- a/app/views/pages/privacy.html.haml
+++ b/app/views/pages/privacy.html.haml
@@ -16,27 +16,26 @@
             beneficial ownership information we collect and publish as part of
             the Open Ownership Register.
           %p
-            It serves to inform data subjects about the uses of their personal information
-            and their data protection rights in circumstances where providing privacy information
-            directly to the data subjects is disproportionate to the processing of this information.
+          It serves to inform data subjects about the uses of their personal information 
+          and their data protection rights in circumstances where providing privacy information 
+          directly to the data subjects is disproportionate to the processing of this information.
           %p
             Please refer to our <a href="https://www.openownership.org/privacy/">
             main privacy policy</a> for details of cookies, data
-            processors, security and contact details of our Data Protection
+            processors, security and contact details of our Data Protection 
             representative.
-          %h2{ id: 'personal-information' } Personal Information
+          %h2{ id: 'personal-information' }
           %p
             We obtain beneficial ownership information from official sources of
-            corporate information. These sources include, but are not limited to:
-          %ul
+            corporate information. These sources include, but are not limited to: 
             %li
-              The UK’s Persons of Significant Control (PSC) Register
+            • The UK’s Persons of Significant Control (PSC) Register
             %li
-              Denmark Central Business Register (CVR)
+            • Denmark Central Business Register (CVR)
             %li
-              Slovakia Public Sector Partners Register
+            • Slovakia Public Sector Partners Register
             %li
-              Ukraine Unified States Register (EDR)
+            • Ukraine Unified States Register (EDR)
           %p
             For a full list of our sources see 
             %a{ href: "/faq" }
@@ -54,7 +53,7 @@
               other information about that individual, including nationality,
               date of birth and occasionally occupation..
           %p
-            As reflected above, we aim to be completely open and transparent about
+            As reflected above, we aim to be completely open and transparent about 
             the source of information we collect and wherever possible we publish a link to
             the source of the data we have collected.
 
@@ -65,24 +64,24 @@
               personal information
             available in order to further our journalistic mission - namely,
             making information about the ownership of corporations available to
-            the public.
-
-          %h3 Publishing for journalistic purposes
-          %p
-            In the vast majority of cases, the personal information we collect has been made
-            public by the data subject themselves through the submission of such information
-            to a public register.
-          %p
-            For onward processing, we rely on the exemptions which derive from
+            the public. 
+           
+           %h3 Publishing for journalistic purposes
+           %p
+           In the vast majority of cases, the personal information we collect has been made 
+           public by the data subject themselves through the submission of such information 
+           to a public register.
+           %p
+           For onward processing, we rely on the exemptions which derive from
             %a{ href: "https://gdpr-info.eu/art-85-gdpr/" }
               Article 85 (2) of the General Data Protection Regulation
             , which covers processing for journalistic purposes and exempts us
             from the need to specify a lawful basis for that processing.
           %p
-            The processing of beneficial ownership data and related personal
-            information in the Open Ownership Register is vital to reducing
-            corruption and tax evasion, giving fairer development opportunities,
-            building societal trust, and enhancing corporate transparency.
+          The processing of beneficial ownership data and related personal 
+          information in the Open Ownership Register is vital to reducing 
+          corruption and tax evasion, giving fairer development opportunities, 
+          building societal trust, and enhancing corporate transparency.
 
           %h3 How we use your personal information and who can access it
           %p
@@ -143,12 +142,12 @@
           %p
             Note that our journalistic mission related to beneficial ownership
             information means that an individual's request to have
-            information about them erased will be subject to the application of
+            information about them erased will be subject to the application of 
             the journalistic exemption (see Redacting information below).
-
+            
           %h3 How to contact us
-          %p
-            If you would like to exercise any of those rights, please:
+          %p 
+          If you would like to exercise any of those rights, please:
           %ul
             %li
               send a request to
@@ -204,15 +203,15 @@
             database to be accessed from anywhere in the world. Making such
             information available to all without restriction is consistent with
             our journalistic mission.
-
+            
+          
           %h2{ id: 'how-to-complain' } How to complain
           %p
-            You have the right to make a complaint at any time to the Information
-            Commissioner's Office (ICO), the UK regulator for data protection issues
-            (www.ico.org.uk) or your national EU Data Protection Authority. We would,
-            however, appreciate the chance to deal with your concerns before you
-            approach the ICO or relevant Data Protection Authority, so please contact
-            us in the first instance.
-
-          %strong
-            Last updated December 2022
+          You have the right to make a complaint at any time to the Information 
+          Commissioner's Office (ICO), the UK regulator for data protection issues 
+          (www.ico.org.uk) or your national EU Data Protection Authority. We would, 
+          however, appreciate the chance to deal with your concerns before you 
+          approach the ICO or relevant Data Protection Authority, so please contact 
+          us in the first instance.
+            %strong
+              Last updated December 2022

--- a/app/views/pages/privacy.html.haml
+++ b/app/views/pages/privacy.html.haml
@@ -12,34 +12,17 @@
           %h2{ id: 'introduction' }
           %p
             This page contains information supplementary to our main
-            organisational privacy policy. It specifically relates to the
+            organisational privacy policy, specifically relating to the
             beneficial ownership information we collect and publish as part of
             the Open Ownership Register.
           %p
-          It serves to inform data subjects about the uses of their personal information 
-          and their data protection rights in circumstances where providing privacy information 
-          directly to the data subjects is disproportionate to the processing of this information.
-          %p
             Please refer to our <a href="https://www.openownership.org/privacy/">
             main privacy policy</a> for details of cookies, data
-            processors, security and contact details of our Data Protection 
-            representative.
+            processors, security and contact details.
           %h2{ id: 'personal-information' }
           %p
             We obtain beneficial ownership information from official sources of
-            corporate information. These sources include, but are not limited to: 
-            %li
-            • The UK’s Persons of Significant Control (PSC) Register
-            %li
-            • Denmark Central Business Register (CVR)
-            %li
-            • Slovakia Public Sector Partners Register
-            %li
-            • Ukraine Unified States Register (EDR)
-          %p
-            For a full list of our sources see 
-            %a{ href: "/faq" }
-              our FAQ.
+            corporate information.
           %p
             The information that we collect will vary from territory to
             territory depending on the information contained on the official
@@ -53,35 +36,29 @@
               other information about that individual, including nationality,
               date of birth and occasionally occupation..
           %p
-            As reflected above, we aim to be completely open and transparent about 
-            the source of information we collect and wherever possible we publish a link to
-            the source of the data we have collected.
+            We aim to be completely open and transparent about the source of
+            information we collect and wherever possible we publish a link to
+            the source of the data we have collected. For a full list of our
+            sources see
+            %a{ href: "/faq" }
+              our FAQ.
 
           %h3 Reasons we can collect and use your personal information
           %p
             We collect, store, use and make
-            %a{ href: "https://standard.openownership.org/en/latest/schema/schema-browser.html#schema-browser-person" }
+            %a{ href: "http://standard.openownership.org/en/schema-beta-2/schema/schema-browser.html#schema-browser-person" }
               personal information
             available in order to further our journalistic mission - namely,
             making information about the ownership of corporations available to
-            the public. 
-           
-           %h3 Publishing for journalistic purposes
-           %p
-           In the vast majority of cases, the personal information we collect has been made 
-           public by the data subject themselves through the submission of such information 
-           to a public register.
-           %p
-           For onward processing, we rely on the exemptions which derive from
+            the public. We rely on
             %a{ href: "https://gdpr-info.eu/art-85-gdpr/" }
-              Article 85 (2) of the General Data Protection Regulation
+              Article 85 of the General Data Protection Regulation
             , which covers processing for journalistic purposes and exempts us
-            from the need to specify a lawful basis for that processing.
+            from finding a lawful basis for that processing.
           %p
-          The processing of beneficial ownership data and related personal 
-          information in the Open Ownership Register is vital to reducing 
-          corruption and tax evasion, giving fairer development opportunities, 
-          building societal trust, and enhancing corporate transparency.
+            In the vast majority of cases, the personal information we collect
+            has been made public by the data subject themselves through the
+            submission of such information to a public register.
 
           %h3 How we use your personal information and who can access it
           %p
@@ -91,7 +68,7 @@
             and obtain copies of the information about you.
 
           %p
-            In addition to public access, we use some third-party data
+            In addition to public access, we use some third party data
             processors to help us run this website and share data with them.
             They are listed in the main Open Ownership Privacy policy.
 
@@ -102,7 +79,7 @@
           %p
             Maintaining this on an on-going basis is fundamental to our
             information mission, and is particularly important for those using
-            our services for journalistic purposes. Matters requiring the
+            our services for investigative purposes. Matters requiring the
             availability of beneficial ownership data may arise for many years
             after a company has ceased to exist.
           %p
@@ -141,13 +118,10 @@
               you;
           %p
             Note that our journalistic mission related to beneficial ownership
-            information means that an individual's request to have
-            information about them erased will be subject to the application of 
-            the journalistic exemption (see Redacting information below).
-            
-          %h3 How to contact us
-          %p 
-          If you would like to exercise any of those rights, please:
+            information means that we do not give individuals the right to have
+            information about them erased other than as set out below (see
+            Redacting information below).
+          %p If you would like to exercise any of those rights, please:
           %ul
             %li
               send a request to
@@ -172,7 +146,7 @@
             If we are informed that a public company register has removed (or
             limited access to) certain information about a person concerned with
             a company due to exceptional circumstances (for example, because of
-            a serious risk to personal safety), we will take steps to promptly:
+            a serious risk to personal safety), we will:
           %ul
             %li update the Open Ownership records in a timely manner; and
             %li
@@ -187,7 +161,7 @@
           %p
             You can inform us of any application made to a public company
             register to remove or limit access to your information by
-            contacting us (see above, How to contact us). Your request should
+            contacting us (see below, How to contact us). Your request should
             contain full details of the reasons for requesting such removal or
             limitation. Note that requests for redaction of personal information
             must be made by the individual concerned or their legal
@@ -203,15 +177,7 @@
             database to be accessed from anywhere in the world. Making such
             information available to all without restriction is consistent with
             our journalistic mission.
-            
-          
-          %h2{ id: 'how-to-complain' } How to complain
+
           %p
-          You have the right to make a complaint at any time to the Information 
-          Commissioner's Office (ICO), the UK regulator for data protection issues 
-          (www.ico.org.uk) or your national EU Data Protection Authority. We would, 
-          however, appreciate the chance to deal with your concerns before you 
-          approach the ICO or relevant Data Protection Authority, so please contact 
-          us in the first instance.
             %strong
-              Last updated December 2022
+              Last updated November 2020


### PR DESCRIPTION
register-v1 old `master` has been moved to `release-1` branch. Everything has also been tagged with `1.0` tag.

Heroku register-v1-stg has been changed to auto-deploy from `release-1` instead of `master`. It has also been put into maintenance. prd continues to use promotion from stg, so no change there.

register-v1 `master` is being reverted to create a zero-diff between `HEAD` and `6ff8c80`, which is contained in register-v2 `master`.

register-v2 will then be put into read-only mode and merged into register-v1 `master`.

There are no other branches left in register-v1 or register-v2. All stale branches (~6+ months old) have been deleted. Younger branches with unmerged code have been queried; none were intended for merge. All outstanding PRs in both register-v1 and register-v2 have been closed without merge, which was also queried and confirmed with the authors.

Heroku register-v2-stg (up-to-date stg) will afterwards be changed to deploy from register-v1 rather than register-v2. prd continues to use promotion from stg, so no change there. Everything has also been tagged with `2.0` tag (all v2 repos, not just register).

cc @StephenAbbott, @spacesnottabs 

