### PR TITLE
[#187] add pages#download_latest

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -16,6 +16,11 @@ class PagesController < ApplicationController
     @example_composite_unofficial_person_identifier = formatted_json(example_composite_unofficial_person_identifier)
   end
 
+  def download_latest
+    exports = BODS_EXPORT_REPOSITORY.completed_exports(limit: 1)
+    redirect_to "https://#{ENV.fetch('BODS_EXPORT_S3_BUCKET_NAME')}.s3-eu-west-1.amazonaws.com/#{exports.first.s3_path}"
+  end
+
   def data_changelog
     @exports = BODS_EXPORT_REPOSITORY.completed_exports(limit: 5)
   end

--- a/app/views/pages/download.html.haml
+++ b/app/views/pages/download.html.haml
@@ -260,7 +260,7 @@
               %h5.card-title Latest data
               %p Exported: #{@exports.first.created_at.to_date}
               %p
-                = link_to "https://#{ENV['BODS_EXPORT_S3_BUCKET_NAME']}.s3-eu-west-1.amazonaws.com/#{@exports.first.s3_path}", rel: 'nofollow', class: 'btn btn-primary', id: 'latest-data' do
+                = link_to download_latest_path, rel: 'nofollow', class: 'btn btn-primary', id: 'latest-data' do
                   Download &nbsp;<i class='fa fa-download'></i>
         .card
           .card-block

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
   get 'faq' => 'pages#faq'
   get 'glossary' => 'pages#glossary'
   get 'download' => 'pages#download'
+  get 'download/latest' => 'pages#download_latest'
   get 'data-changelog' => 'pages#data_changelog'
   resources :data_sources, only: %i[index show]
   root "pages#home"


### PR DESCRIPTION
Register 1 offered a static link to the latest data file in AWS S3, as well as links to individual files. Register 2 and friends doesn't write this file into AWS S3. Instead, add a new route, which will redirect to the latest AWS S3 file, offering the same behaviour as before, but at a different URL.

References https://github.com/openownership/register/issues/187 .