### PR TITLE
28 million

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -107,7 +107,7 @@ en:
     data_changelog:
       title: Data changelog
     home:
-      title: Search over 27 million beneficial ownership records
+      title: Search over 28 million beneficial ownership records
   relationships:
     provenance:
       unknown: Not yet uploaded


### PR DESCRIPTION
Open Ownership Register dataset has now ticked up over 28 million ownership-or-control interests https://bods-data.openownership.org/source/register/